### PR TITLE
Fix pkgstats font in README.qmd

### DIFF
--- a/README.qmd
+++ b/README.qmd
@@ -371,7 +371,7 @@ Tools useful across all stages of package development (some of these are meta-pa
 
 - [`{pkgcheck}`](https://docs.ropensci.org/pkgcheck/) (checks if package follows good practices recommended for packages in the [`rOpenSci`](https://ropensci.org/) ecosystem)
 
-- [{pkgstats}](https://docs.ropensci.org/pkgstats/) (a static code analysis tool)
+- [`{pkgstats}`](https://docs.ropensci.org/pkgstats/) (a static code analysis tool)
 
 - [`{rchk}`](https://github.com/kalibera/rchk/) (provides several bug-finding tools that look for memory protection errors in C source code using R API)
 


### PR DESCRIPTION
Fixed font of "{pkgstats}" to match the rest of the packages in README.qmd. In .qmd as the rest of the files (.md, .html, .pdf) are generated from it based on render-README GitHub Workflow and renderer.R